### PR TITLE
feat: Add fundraising section

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
                     <li><a href="#youtube">Videos</a></li>
                     <li><a href="#merch">Merch</a></li>
                     <li><a href="#affiliates">Affiliates</a></li>
+                    <li><a href="#fundraising">Fundraising</a></li>
                     <li><a href="https://www.patreon.com/c/pezliz/posts" target="_blank" rel="noopener">Patreon</a></li>
                 </ul>
             </nav>
@@ -95,6 +96,23 @@
                     <div class="merch-carousel-dots" id="merch-dots" aria-label="Carousel pages"></div>
                 </div>
                 <p class="merch-cta"><a href="https://pezliz-shop.fourthwall.com/" target="_blank" rel="noopener" class="merch-link">View full shop →</a></p>
+            </div>
+        </section>
+
+        <section id="fundraising">
+            <div class="container">
+                <h2><i class="fas fa-hand-holding-heart"></i> Fundraising Initiatives</h2>
+                <p class="affiliate-intro">Support PezLiz's fundraising initiatives.</p>
+                <div class="affiliate-links">
+                    <a href="https://tiltify.com/@pezliz/profile" target="_blank" rel="noopener" class="affiliate-card">
+                        <h3>St. Jude's Profile</h3>
+                        <p>Support PezLiz's St. Jude fundraising efforts on Tiltify.</p>
+                    </a>
+                    <a href="http://coin.techjeeper.com" target="_blank" rel="noopener" class="affiliate-card">
+                        <h3>Stab The Bag Decision Coin</h3>
+                        <p>Get the limited fundraiser coin. All proceeds go to the St. Jude's fundraiser!</p>
+                    </a>
+                </div>
             </div>
         </section>
 


### PR DESCRIPTION
Adds a new "Fundraising Initiatives" section to the website, as requested. The section includes links to PezLiz's St. Jude fundraising efforts on Tiltify, as well as a link to the "Stab The Bag Decision Coin" site. The section reuses the existing styling from the Affiliates section to ensure visual consistency, and a link to the new section has been added to the main top navigation menu.

---
*PR created automatically by Jules for task [10674459692876522119](https://jules.google.com/task/10674459692876522119) started by @TechJeeper*