### PR TITLE
Fix fundraising subtext styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@
         <section id="fundraising">
             <div class="container">
                 <h2><i class="fas fa-hand-holding-heart"></i> Fundraising Initiatives</h2>
-                <p class="affiliate-intro">Support PezLiz's fundraising initiatives.</p>
+                <p class="fundraising-intro">Support PezLiz's fundraising initiatives.</p>
                 <div class="affiliate-links">
                     <a href="https://tiltify.com/@pezliz/profile" target="_blank" rel="noopener" class="affiliate-card">
                         <h3>St. Jude's Profile</h3>

--- a/style.css
+++ b/style.css
@@ -475,7 +475,8 @@ section h2 {
     font-weight: 700;
 }
 
-#affiliates .affiliate-intro {
+#affiliates .affiliate-intro,
+#fundraising .fundraising-intro {
     max-width: 640px;
     margin: 0 auto 2rem;
     font-size: 1.1rem;


### PR DESCRIPTION
Fixed the subtext styling under the Fundraising section to match similar subtext in other sections (e.g. Affiliates). Renamed the `affiliate-intro` class on the fundraising `<p>` tag to `fundraising-intro` and extended the CSS rules in `style.css` to cover `#fundraising .fundraising-intro` so it correctly centers and wraps the text.

---
*PR created automatically by Jules for task [557286361347912367](https://jules.google.com/task/557286361347912367) started by @TechJeeper*